### PR TITLE
Feat/liking content

### DIFF
--- a/app/Http/Controllers/LikeController.php
+++ b/app/Http/Controllers/LikeController.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Like;
+use Illuminate\Http\Request;
+use Illuminate\Database\Eloquent\Relations\Relation;
+use Illuminate\Support\Facades\Gate;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+
+class LikeController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     */
+    public function index()
+    {
+        //
+    }
+
+    /**
+     * Show the form for creating a new resource.
+     */
+    public function create()
+    {
+        //
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     */
+    public function store(Request $request, string $type, int $id)
+    {
+        $likeable = $this->findLikeable($type, $id);
+        Gate::authorize('create', [Like::class, $likeable]);
+
+        $likeable->likes()->create([
+            'user_id' => $request->user()->id,
+            'likeable_id' => $id,
+            'likeable_type' => $type,
+        ]);
+        $likeable->increment('likes_count');
+
+        return back();
+    }
+
+    /**
+     * Display the specified resource.
+     */
+    public function show(Like $like)
+    {
+        //
+    }
+
+    /**
+     * Show the form for editing the specified resource.
+     */
+    public function edit(Like $like)
+    {
+        //
+    }
+
+    /**
+     * Update the specified resource in storage.
+     */
+    public function update(Request $request, Like $like)
+    {
+        //
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     */
+    public function destroy(Like $like)
+    {
+        //
+    }
+
+    protected function findLikeable(string $likeableType, int $likeableId) {
+        $modelName = Relation::getMorphedModel($likeableType);
+
+        if ($modelName === null) {
+            throw new ModelNotFoundException();
+        }
+
+        return $modelName::findOrFail($likeableId);
+    }
+}

--- a/app/Http/Controllers/LikeController.php
+++ b/app/Http/Controllers/LikeController.php
@@ -11,22 +11,6 @@ use Illuminate\Database\Eloquent\ModelNotFoundException;
 class LikeController extends Controller
 {
     /**
-     * Display a listing of the resource.
-     */
-    public function index()
-    {
-        //
-    }
-
-    /**
-     * Show the form for creating a new resource.
-     */
-    public function create()
-    {
-        //
-    }
-
-    /**
      * Store a newly created resource in storage.
      */
     public function store(Request $request, string $type, int $id)
@@ -45,35 +29,17 @@ class LikeController extends Controller
     }
 
     /**
-     * Display the specified resource.
-     */
-    public function show(Like $like)
-    {
-        //
-    }
-
-    /**
-     * Show the form for editing the specified resource.
-     */
-    public function edit(Like $like)
-    {
-        //
-    }
-
-    /**
-     * Update the specified resource in storage.
-     */
-    public function update(Request $request, Like $like)
-    {
-        //
-    }
-
-    /**
      * Remove the specified resource from storage.
      */
-    public function destroy(Like $like)
+    public function destroy(Request $request, string $type, int $id)
     {
-        //
+        $likeable = $this->findLikeable($type, $id);
+        Gate::authorize('delete', [Like::class, $likeable]);
+
+        $likeable->likes()->whereBelongsTo($request->user())->delete();
+        $likeable->decrement('likes_count');
+
+        return back();
     }
 
     protected function findLikeable(string $likeableType, int $likeableId) {

--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -81,8 +81,14 @@ class PostController extends Controller
         $comments = $post->comments()->with('user')->orderBy('id', 'desc')->paginate(10);
 
         return Inertia::render('Posts/Show', [
-            'post' => fn () => PostResource::make($post),
-            'comments' => fn () => CommentResource::collection($comments),
+            'post' => fn () => PostResource::make($post)->withLikePermission(),
+            'comments' => function () use ($post, $comments) {
+                $commentResourceCollection = CommentResource::collection($comments);
+
+                $commentResourceCollection->collection->transform(fn ($resource) => $resource->withLikePermission());
+
+                return $commentResourceCollection;
+            },
         ]);
     }
 

--- a/app/Http/Resources/CommentResource.php
+++ b/app/Http/Resources/CommentResource.php
@@ -4,6 +4,7 @@ namespace App\Http\Resources;
 
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
+use Illuminate\Support\Number;
 
 class CommentResource extends JsonResource
 {
@@ -20,6 +21,7 @@ class CommentResource extends JsonResource
             'post' => PostResource::make($this->whenLoaded('topic')),
             'body' => $this->body,
             'html' => $this->html,
+            'likes_count' => Number::abbreviate($this->likes_count),
             'created_at' => $this->created_at,
             'updated_at' => $this->updated_at,
             'can' => [

--- a/app/Http/Resources/CommentResource.php
+++ b/app/Http/Resources/CommentResource.php
@@ -5,9 +5,18 @@ namespace App\Http\Resources;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
 use Illuminate\Support\Number;
+use App\Models\Like;
 
 class CommentResource extends JsonResource
 {
+    private bool $withLikePermission = false;
+
+    public function withLikePermission(): self {
+        $this->withLikePermission = true;
+
+        return $this;
+    }
+
     /**
      * Transform the resource into an array.
      *
@@ -27,6 +36,7 @@ class CommentResource extends JsonResource
             'can' => [
                 'update' => $request->user()?->can('update', $this->resource),
                 'delete' => $request->user()?->can('delete', $this->resource),
+                'like' => $this->when($this->withLikePermission, fn () => $request->user()?->can('create', [Like::class, $this->resource])),
             ],
         ];
     }

--- a/app/Http/Resources/PostResource.php
+++ b/app/Http/Resources/PostResource.php
@@ -22,6 +22,7 @@ class PostResource extends JsonResource
             'title' => $this->title,
             'body' => $this->body,
             'html' => str($this->html),
+            'likes_count' => $this->likes_count,
             'updated_at' => $this->updated_at,
             'created_at' => $this->created_at,
             'routes' => [

--- a/app/Http/Resources/PostResource.php
+++ b/app/Http/Resources/PostResource.php
@@ -4,6 +4,7 @@ namespace App\Http\Resources;
 
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
+use Illuminate\Support\Number;
 
 class PostResource extends JsonResource
 {
@@ -22,7 +23,7 @@ class PostResource extends JsonResource
             'title' => $this->title,
             'body' => $this->body,
             'html' => str($this->html),
-            'likes_count' => $this->likes_count,
+            'likes_count' => Number::abbreviate($this->likes_count),
             'updated_at' => $this->updated_at,
             'created_at' => $this->created_at,
             'routes' => [

--- a/app/Http/Resources/PostResource.php
+++ b/app/Http/Resources/PostResource.php
@@ -5,9 +5,18 @@ namespace App\Http\Resources;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
 use Illuminate\Support\Number;
+use App\Models\Like;
 
 class PostResource extends JsonResource
 {
+    private bool $withLikePermission = false;
+
+    public function withLikePermission(): self {
+        $this->withLikePermission = true;
+
+        return $this;
+    }
+
     /**
      * Transform the resource into an array.
      *
@@ -28,6 +37,9 @@ class PostResource extends JsonResource
             'created_at' => $this->created_at,
             'routes' => [
                 'show' => $this->showRoute(),
+            ],
+            'can' => [
+                'like' => $this->when($this->withLikePermission, fn () => $request->user()?->can('create', [Like::class, $this->resource])),
             ],
         ];
     }

--- a/app/Models/Comment.php
+++ b/app/Models/Comment.php
@@ -7,6 +7,7 @@ use App\Models\Post;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\MorphMany;
 
 class Comment extends Model
 {
@@ -20,5 +21,9 @@ class Comment extends Model
 
     public function user(): BelongsTo {
         return $this->belongsTo(User::class);
+    }
+
+    public function likes(): MorphMany {
+        return $this->morphMany(Like::class, 'likeable');
     }
 }

--- a/app/Models/Like.php
+++ b/app/Models/Like.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
+
+class Like extends Model
+{
+    /** @use HasFactory<\Database\Factories\LikeFactory> */
+    use HasFactory;
+
+    public function user(): BelongsTo {
+        return $this->belongsTo(User::class);
+    }
+
+    public function likeable(): MorphTo {
+        return $this->morphTo();
+    }
+}

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -10,6 +10,7 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Support\Str;
 use App\Models\Concerns\ConvertsMarkdownToHtml;
+use Illuminate\Database\Eloquent\Relations\MorphMany;
 
 class Post extends Model
 {
@@ -23,6 +24,10 @@ class Post extends Model
 
     public function comments(): HasMany {
         return $this->hasMany(Comment::class);
+    }
+
+    public function likes(): MorphMany {
+        return $this->morphMany(Like::class, 'likeable');
     }
 
     public function title(): Attribute {

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -18,6 +18,8 @@ class Post extends Model
     use HasFactory;
     use ConvertsMarkdownToHtml;
 
+    protected $withCount = ['likes'];
+
     public function user(): BelongsTo {
         return $this->belongsTo(User::class);
     }

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -18,8 +18,6 @@ class Post extends Model
     use HasFactory;
     use ConvertsMarkdownToHtml;
 
-    protected $withCount = ['likes'];
-
     public function user(): BelongsTo {
         return $this->belongsTo(User::class);
     }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -70,4 +70,8 @@ class User extends Authenticatable implements MustVerifyEmail
     public function comments(): HasMany {
         return $this->hasMany(Comment::class);
     }
+
+    public function likes(): HasMany {
+        return $this->hasMany(Like::class);
+    }
 }

--- a/app/Policies/LikePolicy.php
+++ b/app/Policies/LikePolicy.php
@@ -50,9 +50,14 @@ class LikePolicy
     /**
      * Determine whether the user can delete the model.
      */
-    public function delete(User $user, Like $like): bool
+    public function delete(User $user, Model $likeable): bool
     {
-        return false;
+        if (! in_array($likeable::class, [Post::class, Comment::class])) {
+            return false;
+        }
+
+        // return $likeable->likes()->whereBelongsTo($user)->exists();
+        return $likeable->likes_count > 0;
     }
 
     /**

--- a/app/Policies/LikePolicy.php
+++ b/app/Policies/LikePolicy.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\Like;
+use App\Models\User;
+use Illuminate\Auth\Access\Response;
+use Illuminate\Database\Eloquent\Model;
+use App\Models\Post;
+use App\Models\Comment;
+
+class LikePolicy
+{
+    /**
+     * Determine whether the user can view any models.
+     */
+    public function viewAny(User $user): bool
+    {
+        return false;
+    }
+
+    /**
+     * Determine whether the user can view the model.
+     */
+    public function view(User $user, Like $like): bool
+    {
+        return false;
+    }
+
+    /**
+     * Determine whether the user can create models.
+     */
+    public function create(User $user, Model $likeable): bool
+    {
+        if (! in_array($likeable::class, [Post::class, Comment::class])) {
+            return false;
+        }
+
+        return $likeable->likes()->whereBelongsTo($user)->doesntExist();
+    }
+
+    /**
+     * Determine whether the user can update the model.
+     */
+    public function update(User $user, Like $like): bool
+    {
+        return false;
+    }
+
+    /**
+     * Determine whether the user can delete the model.
+     */
+    public function delete(User $user, Like $like): bool
+    {
+        return false;
+    }
+
+    /**
+     * Determine whether the user can restore the model.
+     */
+    public function restore(User $user, Like $like): bool
+    {
+        return false;
+    }
+
+    /**
+     * Determine whether the user can permanently delete the model.
+     */
+    public function forceDelete(User $user, Like $like): bool
+    {
+        return false;
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -8,6 +8,7 @@ use Illuminate\Support\ServiceProvider;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use App\Models\Post;
 use App\Models\Comment;
+use App\Models\User;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -33,6 +34,7 @@ class AppServiceProvider extends ServiceProvider
         Relation::enforceMorphMap([
             'post' => Post::class,
             'comment' => Comment::class,
+            'user' => User::class,
         ]);
     }
 }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -5,6 +5,9 @@ namespace App\Providers;
 use App\Http\Resources\PostResource;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Database\Eloquent\Relations\Relation;
+use App\Models\Post;
+use App\Models\Comment;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -26,5 +29,10 @@ class AppServiceProvider extends ServiceProvider
         Model::preventLazyLoading();
 
         Model::unguard();
+
+        Relation::enforceMorphMap([
+            'post' => Post::class,
+            'comment' => Comment::class,
+        ]);
     }
 }

--- a/database/factories/CommentFactory.php
+++ b/database/factories/CommentFactory.php
@@ -22,6 +22,7 @@ class CommentFactory extends Factory
             'user_id' => User::factory(),
             'post_id' => Post::factory(),
             'body' => fake()->realText(),
+            'likes_count' => 0,
         ];
     }
 }

--- a/database/factories/LikeFactory.php
+++ b/database/factories/LikeFactory.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+use App\Models\User;
+use App\Models\Post;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Like>
+ */
+class LikeFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'user_id' => User::factory(),
+            'likeable_type' => Post::class,
+            'likeable_id' => Post::factory(),
+        ];
+    }
+}

--- a/database/factories/LikeFactory.php
+++ b/database/factories/LikeFactory.php
@@ -20,8 +20,15 @@ class LikeFactory extends Factory
     {
         return [
             'user_id' => User::factory(),
-            'likeable_type' => Post::class,
+            'likeable_type' => $this->likeableType(...),
             'likeable_id' => Post::factory(),
         ];
+    }
+
+    protected function likeableType(array $values) {
+        $type = $values['likeable_id'];
+        $modelName = $type->modelName();
+
+        return (new $modelName)->getMorphClass();
     }
 }

--- a/database/factories/LikeFactory.php
+++ b/database/factories/LikeFactory.php
@@ -5,6 +5,7 @@ namespace Database\Factories;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use App\Models\User;
 use App\Models\Post;
+use Illuminate\Support\Str;
 
 /**
  * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Like>
@@ -19,7 +20,7 @@ class LikeFactory extends Factory
     public function definition(): array
     {
         return [
-            'user_id' => User::factory(),
+            'user_id' => User::factory(['email' => 'test+' . Str::uuid() . '@example.com']),
             'likeable_type' => $this->likeableType(...),
             'likeable_id' => Post::factory(),
         ];

--- a/database/factories/LikeFactory.php
+++ b/database/factories/LikeFactory.php
@@ -27,7 +27,9 @@ class LikeFactory extends Factory
 
     protected function likeableType(array $values) {
         $type = $values['likeable_id'];
-        $modelName = $type->modelName();
+        $modelName = $type instanceof Factory
+            ? $type->modelName()
+            : $type::class;
 
         return (new $modelName)->getMorphClass();
     }

--- a/database/factories/PostFactory.php
+++ b/database/factories/PostFactory.php
@@ -27,6 +27,7 @@ class PostFactory extends Factory
             'topic_id' => Topic::factory(),
             'title' => str(fake()->sentence)->beforeLast('.')->title(),
             'body' => Collection::times(4, fn () => fake()->realText(1250))->join(PHP_EOL . PHP_EOL),
+            'likes_count' => 0,
         ];
     }
 

--- a/database/migrations/2025_07_16_000255_create_posts_table.php
+++ b/database/migrations/2025_07_16_000255_create_posts_table.php
@@ -18,6 +18,7 @@ return new class extends Migration
             $table->string('title');
             $table->longText('body');
             $table->longText('html');
+            $table->unsignedBigInteger('likes_count')->default(0);
             $table->timestamps();
         });
     }

--- a/database/migrations/2025_07_16_002428_create_comments_table.php
+++ b/database/migrations/2025_07_16_002428_create_comments_table.php
@@ -19,6 +19,7 @@ return new class extends Migration
             $table->foreignIdFor(Post::class)->constrained()->cascadeOnDelete();
             $table->longText('body');
             $table->longText('html');
+            $table->unsignedBigInteger('likes_count')->default(0);
             $table->timestamps();
         });
     }

--- a/database/migrations/2025_10_12_174507_create_likes_table.php
+++ b/database/migrations/2025_10_12_174507_create_likes_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use App\Models\User;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('likes', function (Blueprint $table) {
+            $table->id();
+            $table->foreignIdFor(User::class)->constrained()->cascadeOnDelete();
+            $table->morphs('likeable');
+            $table->timestamps();
+
+            $table->unique(['user_id', 'likeable_type', 'likeable_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('likes');
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -8,6 +8,7 @@ use App\Models\User;
 use App\Models\Comment;
 use Illuminate\Database\Seeder;
 use App\Models\Topic;
+use App\Models\Like;
 
 class DatabaseSeeder extends Seeder
 {
@@ -30,6 +31,9 @@ class DatabaseSeeder extends Seeder
         User::factory()
             ->has(Post::factory(50)->recycle($topics)->withFixture())
             ->has(Comment::factory(100)->recycle($posts))
+            ->has(Like::factory()->forEachSequence(
+                ...$posts->random(100)->map(fn (Post $post) => ['likeable_id' => $post]),
+            ))
             ->create([
                 'name' => 'Test User',
                 'email' => 'test@example.com',

--- a/database/seeders/LikeLoadTestSeeder.php
+++ b/database/seeders/LikeLoadTestSeeder.php
@@ -27,5 +27,7 @@ class LikeLoadTestSeeder extends Seeder
             $progress->advance(100);
         });
         $progress->finish();
+
+        $post->increment('likes_count', 500_000);
     }
 }

--- a/database/seeders/LikeLoadTestSeeder.php
+++ b/database/seeders/LikeLoadTestSeeder.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+use App\Models\Like;
+use Illuminate\Support\LazyCollection;
+use App\Models\Post;
+
+use function Laravel\Prompts\progress;
+
+class LikeLoadTestSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        $post = Post::find(1);
+
+        $progress = progress(label: 'Creating likes', steps: 500_000);
+
+        $progress->start();
+        LazyCollection::times(5000)->each(function () use ($post, $progress) {
+            Like::factory(100)->for($post, 'likeable')->create();
+            $progress->advance(100);
+        });
+        $progress->finish();
+    }
+}

--- a/resources/js/Components/Comment.vue
+++ b/resources/js/Components/Comment.vue
@@ -18,7 +18,8 @@ import { router, usePage } from '@inertiajs/vue3';
         <div class="flex-1 flex flex-col">
             <div class="mt-1 prose prose-sm max-w-none" v-html="comment.html"></div>
             <span class="first-letter:uppercase block pt-1 text-xs text-gray-600">
-                By {{ comment.user.name }} {{ formatDate(comment.created_at) }}
+                By {{ comment.user.name }} {{ formatDate(comment.created_at) }} |
+                <span class="text-pink-500">{{ comment.likes_count }} likes</span>
             </span>
             <div class="mt-1 flex justify-end space-x-3">
                 <form v-if="comment.can?.update" @submit.prevent="$emit('edit', comment.id)">

--- a/resources/js/Components/Comment.vue
+++ b/resources/js/Components/Comment.vue
@@ -1,7 +1,8 @@
 <script setup>
 import { computed } from 'vue';
 import { formatDate } from './Utilities/date';
-import { router, usePage } from '@inertiajs/vue3';
+import { Link, router, usePage } from '@inertiajs/vue3';
+import { HandThumbDownIcon, HandThumbUpIcon } from '@heroicons/vue/20/solid';
 
     const props = defineProps(['comment']);
 
@@ -22,6 +23,16 @@ import { router, usePage } from '@inertiajs/vue3';
                 <span class="text-pink-500">{{ comment.likes_count }} likes</span>
             </span>
             <div class="mt-1 flex justify-end space-x-3">
+                <div v-if="$page.props.auth.user">
+                    <Link v-if="comment.can.like" preserve-scroll :href="route('likes.store', ['comment', comment.id])" method="post" class="inline-block hover:text-pink-500 text-gray-7000 transition-colors cursor-pointer">
+                        <HandThumbUpIcon class="size-4 inline-block mr-1" />
+                        <span class="sr-only">Like Comment</span>
+                    </Link>
+                    <Link v-else preserve-scroll :href="route('likes.destroy', ['comment', comment.id])" method="delete" class="inline-block hover:text-pink-500 text-gray-7000 transition-colors cursor-pointer">
+                        <HandThumbDownIcon class="size-4 inline-block mr-1" />
+                        <span class="sr-only">Unlike Comment</span>
+                    </Link>
+                </div>
                 <form v-if="comment.can?.update" @submit.prevent="$emit('edit', comment.id)">
                     <button class="font-mono text-xs">Edit</button>
                 </form>

--- a/resources/js/Pages/Posts/Show.vue
+++ b/resources/js/Pages/Posts/Show.vue
@@ -9,6 +9,10 @@
             <PageHeading class="mt-2">{{ post.title }}</PageHeading>
             <p class="mb-6 text-sm text-gray-500">{{ postDateFormatted }} by {{ post.user.name }}</p>
 
+            <div class="mt-4">
+                <span class="text-pink-500 font-bold">{{ post.likes_count }} likes</span>
+            </div>
+
             <article class="mt-6 prose prose-sm max-w-none" v-html="post.html">
             </article>
 

--- a/resources/js/Pages/Posts/Show.vue
+++ b/resources/js/Pages/Posts/Show.vue
@@ -11,6 +11,17 @@
 
             <div class="mt-4">
                 <span class="text-pink-500 font-bold">{{ post.likes_count }} likes</span>
+
+                <div v-if="$page.props.auth.user" class="mt-2">
+                    <Link v-if="post.can.like" :href="route('likes.store', ['post', post.id])" method="post" class="inline-block bg-indigo-600 hover:bg-pink-500 transition-colors text-white py-1.5 px-3 rounded-full">
+                        <HandThumbUpIcon class="size-4 inline-block mr-1" />
+                        Like Post
+                    </Link>
+                    <Link v-else :href="route('likes.destroy', ['post', post.id])" method="delete" class="inline-block bg-indigo-600 hover:bg-pink-500 transition-colors text-white py-1.5 px-3 rounded-full">
+                        <HandThumbDownIcon class="size-4 inline-block mr-1" />
+                        Unlike Post
+                    </Link>
+                </div>
             </div>
 
             <article class="mt-6 prose prose-sm max-w-none" v-html="post.html">
@@ -53,10 +64,11 @@ import Pagination from '@/Components/Pagination.vue';
 import Pill from '@/Components/Pill.vue';
 import PrimaryButton from '@/Components/PrimaryButton.vue';
 import SecondaryButton from '@/Components/SecondaryButton.vue';
+import { HandThumbUpIcon, HandThumbDownIcon } from '@heroicons/vue/20/solid/index.js';
 import { useConfirm } from '@/Components/Utilities/Composables/useConfirm';
 import { formatDate } from '@/Components/Utilities/date';
 import AppLayout from '@/Layouts/AppLayout.vue';
-import { router, useForm, Head } from '@inertiajs/vue3';
+import { router, useForm, Head, Link } from '@inertiajs/vue3';
 import { computed, ref, watch } from 'vue';
 
 const props = defineProps(['post', 'comments']);

--- a/routes/web.php
+++ b/routes/web.php
@@ -5,6 +5,7 @@ use Illuminate\Support\Facades\Route;
 use Inertia\Inertia;
 use App\Http\Controllers\PostController;
 use App\Http\Controllers\CommentController;
+use App\Http\Controllers\LikeController;
 
 Route::get('/', function () {
     return Inertia::render('Welcome', [
@@ -26,6 +27,8 @@ Route::middleware([
 
     Route::resource('posts', PostController::class)->only(['store', 'create']);
     Route::resource('posts.comments', CommentController::class)->shallow()->only(['store', 'update', 'destroy']);
+
+    Route::post('/likes/{type}/{id}', [LikeController::class, 'store'])->name('likes.store');
 });
 
 Route::get('posts/{topic?}', [PostController::class, 'index'])->name('posts.index');

--- a/routes/web.php
+++ b/routes/web.php
@@ -29,6 +29,7 @@ Route::middleware([
     Route::resource('posts.comments', CommentController::class)->shallow()->only(['store', 'update', 'destroy']);
 
     Route::post('/likes/{type}/{id}', [LikeController::class, 'store'])->name('likes.store');
+    Route::delete('/likes/{type}/{id}', [LikeController::class, 'destroy'])->name('likes.destroy');
 });
 
 Route::get('posts/{topic?}', [PostController::class, 'index'])->name('posts.index');

--- a/tests/Feature/Controllers/LikeController/DestroyTest.php
+++ b/tests/Feature/Controllers/LikeController/DestroyTest.php
@@ -1,0 +1,61 @@
+<?php
+
+use Illuminate\Database\Eloquent\Model;
+
+use function Pest\Laravel\actingAs;
+use function Pest\Laravel\assertDatabaseEmpty;
+use function Pest\Laravel\delete;
+use function Pest\Laravel\withoutExceptionHandling;
+
+use App\Models\User;
+use App\Models\Post;
+use App\Models\Like;
+use App\Models\Comment;
+
+it('requires authentication', function () {
+    delete(route('likes.destroy', ['anything', 'anything']))
+        ->assertRedirect(route('login'));
+});
+
+it('allows unliking a likeable', function (Model $likeable) {
+    /** @var App\Models\User */
+    $user = User::factory()->create();
+    $like = Like::factory()->for($user)->for($likeable, 'likeable')->create();
+
+    actingAs($user)
+        ->fromRoute('dashboard')
+        ->delete(route('likes.destroy', [$likeable->getMorphClass(), $likeable->id]))
+        ->assertRedirect(route('dashboard'));
+
+    assertDatabaseEmpty(Like::class);
+    expect($likeable->refresh()->likes_count)->toBe(0);
+})->with([
+    fn () => Post::factory()->create(['likes_count' => 1]),
+    fn () => Comment::factory()->create(['likes_count' => 1]),
+]);
+
+it('prevents unliking something you havent liked', function () {
+    $likeable = Post::factory()->create();
+
+    actingAs($likeable->user)
+        ->delete(route('likes.destroy', [$likeable->getMorphClass(), $likeable->id]))
+        ->assertForbidden();
+});
+
+it('only allows unliking supported models', function () {
+    /** @var App\Models\User */
+    $user = User::factory()->create();
+
+    actingAs($user)
+        ->delete(route('likes.destroy', [$user->getMorphClass(), $user->id]))
+        ->assertForbidden();
+});
+
+it('throws a 404 if the type is unsupported', function () {
+    /** @var App\Models\User */
+    $user = User::factory()->create();
+
+    actingAs($user)
+        ->delete(route('likes.destroy', ['foo', 1]))
+        ->assertNotFound();
+});

--- a/tests/Feature/Controllers/LikeController/StoreTest.php
+++ b/tests/Feature/Controllers/LikeController/StoreTest.php
@@ -1,0 +1,62 @@
+<?php
+
+use Illuminate\Database\Eloquent\Model;
+
+use function Pest\Laravel\actingAs;
+use function Pest\Laravel\post;
+use App\Models\User;
+use App\Models\Post;
+use App\Models\Like;
+use App\Models\Comment;
+
+it('requires authentication', function () {
+    post(route('likes.store', ['anything', 'anything']))
+        ->assertRedirect(route('login'));
+});
+
+it('allows liking a likeable', function (Model $likeable) {
+    /** @var App\Models\User */
+    $user = User::factory()->create();
+
+    actingAs($user)
+        ->fromRoute('dashboard')
+        ->post(route('likes.store', [$likeable->getMorphClass(), $likeable->id]))
+        ->assertRedirect(route('dashboard'));
+
+    $this->assertDatabaseHas(Like::class, [
+        'user_id' => $user->id,
+        'likeable_id' => $likeable->id,
+        'likeable_type' => $likeable->getMorphClass(),
+    ]);
+    expect($likeable->refresh()->likes_count)->toBe(1);
+})->with([
+    fn () => Post::factory()->create(),
+    fn () => Comment::factory()->create(),
+]);
+
+it('prevents liking something you already liked', function () {
+    $like = Like::factory()->create();
+    $likeable = $like->likeable;
+
+    actingAs($like->user)
+        ->post(route('likes.store', [$likeable->getMorphClass(), $likeable->id]))
+        ->assertForbidden();
+});
+
+it('only allows liking supported models', function () {
+    /** @var App\Models\User */
+    $user = User::factory()->create();
+
+    actingAs($user)
+        ->post(route('likes.store', [$user->getMorphClass(), $user->id]))
+        ->assertForbidden();
+});
+
+it('throws a 404 if the type is unsupported', function () {
+    /** @var App\Models\User */
+    $user = User::factory()->create();
+
+    actingAs($user)
+        ->post(route('likes.store', ['foo', 1]))
+        ->assertNotFound();
+});

--- a/tests/Feature/Controllers/PostController/ShowTest.php
+++ b/tests/Feature/Controllers/PostController/ShowTest.php
@@ -23,7 +23,7 @@ it('passes a post to the view', function () {
     $post->load('user', 'topic');
 
     get($post->showRoute())
-        ->assertHasResource('post', PostResource::make($post));
+        ->assertHasResource('post', PostResource::make($post)->withLikePermission());
 });
 
 it('passes comments to the view', function () {
@@ -32,9 +32,14 @@ it('passes comments to the view', function () {
 
     $comments->load('user');
 
+    $expectedResource = CommentResource::collection($comments);
+    $expectedResource->collection->transform(
+        fn (CommentResource $resource) => $resource->withLikePermission(),
+    );
+
     get($post->showRoute())
         ->assertOk()
-        ->assertHasPaginatedResource('comments', CommentResource::collection($comments));
+        ->assertHasPaginatedResource('comments', $expectedResource);
 });
 
 it('will redirect if the slug is incorrect', function (string $incorrectSlug) {


### PR DESCRIPTION
## Liking Content

### The main points

<ul>
<li>Learn how to identify and implement polymorphic relationships and the pros and cons of the proposed approach (policy, controller, model and relationships, seeders and mock data... in the future this source code can be used as a guide for implementation with good practices). (The lack of database enforcement but the flexibility of code and less database overhead due to multiple relationships.)</li>

<li>Reinforce knowledge about denormalization and why redundancy in database design can be beneficial to the performance of the application (with examples with/without it using a massive amount of mock instances).</li>

<li>How to work around Laravel particularities on calling attributes (methods or properties) on a <code>ResourceCollection</code> instance's children instances (something even GPT can't tell too much about. Perhaps in the future an issue or PR will be opened in the Laravel repository to improve code in these cases).</li>

<li>Reinforce about the Builder Pattern with a use case involving permissioning, DTO, and query optimization.
<ul>
<li>We need to check if the end user can like or unlike posts, for example, but this is not needed on posts listing, so the query must be optional in this case to avoid N+1 on each post. For posts and comments we use DTOs, and for checking like/unliking permission in these we can have a property that sets the need for loading the query (<code>withLikePermission</code>, which defaults to <code>false</code>). The Builder Pattern is welcome because we can make the toggling logic (turn false to true) as simple as calling a method:  
<code>'post' => fn () => PostResource::make($post)->withLikePermission()</code>  
in post show (since in posts listing the <code>withLikePermission</code> in every post will be false and the query won’t be triggered).</li>

<li>In the case of comments, however, it was the opposite: in the posts listing they had to continue false, but in post show we needed to make all comments from the DTO (<code>CommentResource::collection(Comment::all())</code>) have <code>withLikePermission</code> as true. That’s when the need for the workaround mentioned in the previous bullet point occurred.</li>
</ul>
</li>
</ul>
